### PR TITLE
Add a class to the current modified text editor

### DIFF
--- a/keymaps/copy-paste.cson
+++ b/keymaps/copy-paste.cson
@@ -9,4 +9,5 @@
 # https://atom.io/docs/latest/behind-atom-keymaps-in-depth
 'atom-workspace':
   'ctrl-alt-v': 'copy-paste:paste'
+'atom-text-editor.copy-paste-active':
   'escape': 'copy-paste:stop'


### PR DESCRIPTION
This allow to set the binding for the escape key for the editor
currently used by the plugin. This fix the problem of the escape key
binding being overwritten in several context.

Signed-off-by: Marc-Antoine Sauve madeinqchw@gmail.com
